### PR TITLE
chore: Automate nodered axios installation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 services:
   nodered:
-    image: nodered/node-red
+    build:
+      context: .
+      dockerfile: nodered.Dockerfile
     container_name: cblab-nodered-container
     ports:
       - '1880:1880'
     volumes:
-      - ./nodered_data:/data
+      - ./nodered_data:/data 
     restart: unless-stopped
     environment:
       - TZ=America/Sao_Paulo
@@ -28,15 +30,12 @@ services:
     networks:
       - cblab-network
     healthcheck:
-      test: ['CMD-SHELL', 'curl http://localhost:3001/ || exit 1'] # Removi o '-f' para ser mais permissivo, se o Express retornar 200, já passa
-      interval: 15s # Aumenta o intervalo de verificação
-      timeout: 10s # Aumenta o timeout da verificação
+      test: ['CMD-SHELL', 'curl http://localhost:3001/ || exit 1']
+      interval: 15s
+      timeout: 10s
       retries: 5
-      start_period: 30s # Aumenta o período inicial para o serviço se estabilizar
+      start_period: 30s
 
 networks:
   cblab-network:
     driver: bridge
-
-volumes:
-  nodered_data:

--- a/nodered.Dockerfile
+++ b/nodered.Dockerfile
@@ -1,0 +1,10 @@
+FROM nodered/node-red
+
+    # Define o diretório de trabalho onde o Node-RED armazena seus dados e módulos
+    WORKDIR /data
+
+    # Instala o nó node-red-contrib-axios
+    RUN npm install --prefix . node-red-contrib-axios --unsafe-perm
+
+
+    

--- a/nodered.Dockerfile
+++ b/nodered.Dockerfile
@@ -1,10 +1,14 @@
-FROM nodered/node-red
+    # nodered.Dockerfile
 
-    # Define o diretório de trabalho onde o Node-RED armazena seus dados e módulos
-    WORKDIR /data
+    # Usa a imagem oficial do Node-RED como base
+    FROM nodered/node-red
 
     # Instala o nó node-red-contrib-axios
-    RUN npm install --prefix . node-red-contrib-axios --unsafe-perm
+    # Não precisa de WORKDIR /data ou --prefix .
+    # O npm do Node-RED já sabe onde instalar os módulos para que sejam encontrados.
+    RUN npm install node-red-contrib-axios --unsafe-perm
 
-
+    # Define explicitamente o ENTRYPOINT para iniciar o Node-RED
+    # Isso garante que o comando padrão da imagem base seja sobrescrito de forma robusta.
+    ENTRYPOINT ["npm", "start", "--", "--userDir", "/data"]
     


### PR DESCRIPTION
# 🛠️ Automação da Instalação do `node-red-contrib-axios` no Contêiner Node-RED

## 📌 Descrição Detalhada

Este Pull Request implementa a **automação da instalação do nó `node-red-contrib-axios`** no contêiner do Node-RED.

---

## 🎯 Objetivo

Eliminar a necessidade de instalação manual do nó `axios` via *Palette Manager* do Node-RED a cada recriação do contêiner, tornando o ambiente de desenvolvimento mais **consistente** e **fácil de configurar** para outros desenvolvedores e avaliadores.

---

## ⚙️ Alterações Realizadas

### 🐳 Criação do `nodered.Dockerfile`
- Baseado na imagem oficial `nodered/node-red`.
- Inclui o comando:

  ```dockerfile
  RUN npm install node-red-contrib-axios --unsafe-perm
  ```

  para instalar o nó `axios` durante a construção da imagem.
- Define explicitamente o `ENTRYPOINT`:

  ```dockerfile
  ENTRYPOINT ["npm", "start", "--", "--userDir", "/data"]
  ```

  Isso resolve problemas de inicialização anteriores causados pelo `entrypoint.sh` padrão.

---

### 📄 Atualização do `docker-compose.yml`

- O serviço `nodered` foi modificado para:
  - Usar `build:` apontando para o `nodered.Dockerfile`, em vez de `image:`.
  - Garantir que o volume de bind `./nodered_data:/data` esteja configurado corretamente.
  - **Remover volume nomeado redundante** no final do arquivo (`volumes:` com `nodered_data:`).

---

## ✅ Benefícios

- **Automação:** O nó `axios` é instalado automaticamente na construção da imagem.
- **Consistência:** Garante que o ambiente Node-RED esteja sempre pronto com as dependências necessárias.
- **Facilidade de Setup:** Reduz etapas manuais para novos usuários ou em ambientes de CI/CD.
- **Resolução de Erros:** Corrige o erro do `entrypoint.sh` anterior ao definir o `ENTRYPOINT` de forma explícita.

---

## 🧪 Como Testar

1. Execute o comando:

   ```bash
   docker-compose down --volumes --rmi all
   ```

   Isso **limpa completamente o ambiente anterior**, incluindo volumes e imagens antigas.

2. Em seguida, execute:

   ```bash
   docker-compose up --build -d
   ```

   Isso **reconstrói e inicia os contêineres**.

3. Acesse o Node-RED em: [http://localhost:1880](http://localhost:1880)

4. Verifique se o nó `axios` já está disponível na paleta de nós, **sem necessidade de instalação manual**.

5. Importe os fluxos de backup do Node-RED e dispare o fluxo de ingestão para confirmar o funcionamento.

---

## 🔗 Issues Relacionadas

Closes #21 
